### PR TITLE
Refactor/eventbus improved locking

### DIFF
--- a/code.go
+++ b/code.go
@@ -13,7 +13,7 @@ type awaitFunc func(int) []any
 // use fSend and fAwait to communicate between nodes
 func Run(ctx context.Context, fSend sendFunc, fAwait awaitFunc) any {
 	fmt.Println("custom data ", ctx.Value("custom"))
-	fmt.Println("neighbors ", ctx.Value("neighbors"))
+	fmt.Println("neighbors ", ctx.Value("outgoing-connections"))
 	fmt.Println("id ", ctx.Value("id"))
 	res := struct{ foo string }{foo: "bar"}
 	go func() {
@@ -33,8 +33,8 @@ func Run(ctx context.Context, fSend sendFunc, fAwait awaitFunc) any {
 		case <-ctx.Done():
 			return res
 		default:
-			time.Sleep(time.Second * 5)
-			neighbors, ok := ctx.Value("neighbors").([]int)
+			time.Sleep(time.Second * 1)
+			neighbors, ok := ctx.Value("outgoing-connections").([]int)
 			if ok {
 				fmt.Println("send")
 				for _, c := range neighbors {

--- a/core/Node.go
+++ b/core/Node.go
@@ -117,12 +117,16 @@ func (n *node) codeExec(codeCancel chan any, code Code, resChan chan bus.NodeOut
 	i := interp.New(interp.Options{Stdout: &userFOut, Stderr: &userFOut})
 
 	if err := i.Use(stdlib.Symbols); err != nil {
-		panic(err)
+		log.Error(err)
+		return
 	}
 
 	_, err := i.Eval(string(code))
 	if err != nil {
-		panic(err)
+		log.Error(err)
+		data := bus.NodeOutput{Log: err.Error(), Result: nil, NodeId: n.id}
+		resChan <- data
+		return
 	}
 
 	v, err := i.Eval("Run")
@@ -130,6 +134,7 @@ func (n *node) codeExec(codeCancel chan any, code Code, resChan chan bus.NodeOut
 		log.Error(err)
 		data := bus.NodeOutput{Log: err.Error(), Result: nil, NodeId: n.id}
 		resChan <- data
+		return
 	}
 
 	userF := v.Interface().(func(ctx context.Context, fSend func(targetId int, data any) int, fAwait func(cnt int) []any) any)

--- a/core/Node.go
+++ b/core/Node.go
@@ -12,50 +12,67 @@ import (
 )
 
 type Node interface {
-	ConnectTo(peerId int)
-	DisconnectFrom(peerId int)
-	GetConnections() bus.Connections
+	AddOutputTo(peerId int, c chan any)
+	DelOutputTo(peerId int)
+	AddInputFrom(peerId int, c chan any)
+	DelInputFrom(peerId int)
+	GetOutConnections() bus.Connections
 	SetData(json any)
 	Run(eb bus.EventBus, signals <-chan Signal)
 }
 
+// stores a connection between this node and another peer
+// whether its in- or outgoing depends on the context
 type connection struct {
-	to int
-	ch chan any
+	peer int
+	ch   chan any
 }
 
 type node struct {
-	connections []connection
-	id          int
-	data        any // json data to expose to user code
+	ins  []connection // stores connections TO other nodes
+	outs []connection // stores connections FROM other nodes
+	id   int
+	data any // json data to expose to user code
 }
 
 func NewNode(id int) Node {
-	var connections []connection
-	return &node{connections, id, nil}
+	var ins []connection
+	var outs []connection
+	return &node{ins, outs, id, nil}
 }
 
-// make a one way connection from  n to peer, meaning peer adds n's output as
-// input
-func (n *node) ConnectTo(peerId int) {
-	c := make(chan any, 10)
+func (n *node) AddOutputTo(peerId int, c chan any) {
 	newConnection := connection{peerId, c}
-	n.connections = append(n.connections, newConnection)
+	n.outs = append(n.outs, newConnection)
 }
 
-func (n *node) DisconnectFrom(peerId int) {
-	for connI, conn := range n.connections {
-		if conn.to == peerId {
-			n.connections = append(n.connections[:connI], n.connections[connI+1:]...)
+func (n *node) DelOutputTo(peerId int) {
+	for connI, conn := range n.outs {
+		if conn.peer == peerId {
+			n.outs = append(n.outs[:connI], n.outs[connI+1:]...)
 			return
 		}
 	}
 }
 
-func (n *node) GetConnections() bus.Connections {
-	res := make(bus.Connections, len(n.connections))
-	for i, c := range n.connections {
-		res[i] = bus.Connection{From: n.id, To: c.to}
+func (n *node) AddInputFrom(peerId int, c chan any) {
+	newConnection := connection{peerId, c}
+	n.ins = append(n.ins, newConnection)
+}
+
+func (n *node) DelInputFrom(peerId int) {
+	for connI, conn := range n.ins {
+		if conn.peer == peerId {
+			n.ins = append(n.ins[:connI], n.ins[connI+1:]...)
+			return
+		}
+	}
+}
+
+func (n *node) GetOutConnections() bus.Connections {
+	res := make(bus.Connections, len(n.outs))
+	for i, c := range n.outs {
+		res[i] = bus.Connection{From: n.id, To: c.peer}
 	}
 	return res
 }
@@ -70,6 +87,7 @@ func (n *node) Run(eb bus.EventBus, signals <-chan Signal) {
 	code := Code("")
 	eb.Bind(bus.CodeChangeEvt, func(newCode Code) {
 		code = newCode
+		log.Debug("node ", n.id, " received code")
 	})
 
 	var codeCancel chan any
@@ -140,12 +158,12 @@ func (n *node) codeExec(codeCancel chan any, code Code, resChan chan bus.NodeOut
 	userF := v.Interface().(func(ctx context.Context, fSend func(targetId int, data any) int, fAwait func(cnt int) []any) any)
 
 	// make node specific data accessible
-	neighborsIds := make([]int, len(n.connections))
-	for i, c := range n.connections {
-		neighborsIds[i] = c.to
+	neighborsIds := make([]int, len(n.outs))
+	for i, c := range n.outs {
+		neighborsIds[i] = c.peer
 	}
 	ctx = context.WithValue(ctx, "custom", n.data)
-	ctx = context.WithValue(ctx, "neighbors", neighborsIds)
+	ctx = context.WithValue(ctx, "outgoing-connections", neighborsIds)
 	ctx = context.WithValue(ctx, "id", n.id)
 
 	// Execute the provided function
@@ -167,8 +185,8 @@ func (n *node) codeExec(codeCancel chan any, code Code, resChan chan bus.NodeOut
 // TODO : another one to send to all
 // TODO : another one to provide equation, send to all that resolve it e.g. for all even id's
 func (n *node) send(targetId int, data any) int {
-	for _, c := range n.connections {
-		if c.to == targetId {
+	for _, c := range n.outs {
+		if c.peer == targetId {
 			c.ch <- data
 			return 0
 		}
@@ -181,12 +199,13 @@ func (n *node) send(targetId int, data any) int {
 func (n *node) await(cnt int) []any {
 	var wg sync.WaitGroup
 	wg.Add(cnt)
-	// channel to kill those channels where we don't expect a message ?
-	kill := make(chan bool, 10)
+
+	kill := make(chan bool, 10) // channel to send kill signals
 
 	// listen on all channels until the specified number of messages is reached
 	res := []any{}
-	for _, c := range n.connections {
+	log.Debug("Await ", cnt, " from ", len(n.ins), " connections")
+	for _, c := range n.ins {
 		go func(c connection, wg *sync.WaitGroup) {
 			for {
 				select {
@@ -201,7 +220,8 @@ func (n *node) await(cnt int) []any {
 	}
 
 	wg.Wait()
-	for i := 0; i <= len(n.connections)-cnt; i++ {
+
+	for i := 0; i <= len(n.ins)-cnt; i++ {
 		kill <- true
 	}
 

--- a/log/log.go
+++ b/log/log.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"strconv"
+	"sync"
 )
 
 var logLvlFlag = flag.Int("log-level", int(DebugLevel), "set loglevels info, error, debug with 1,2,3")
@@ -28,6 +29,8 @@ const (
 	DebugLevel
 )
 
+var mu = sync.Mutex{}
+
 // log prints the message with the specified color
 func log(colorCode, level string, logLevel LogLevel, optionalErr error, message ...any) {
 	if *logLvlFlag < int(logLevel) {
@@ -36,13 +39,17 @@ func log(colorCode, level string, logLevel LogLevel, optionalErr error, message 
 
 	logPrefix := "%s[%s]%s "
 	if logLevel == ErrorLevel {
+		mu.Lock()
 		fmt.Printf(logPrefix+"%+v\n", colorCode, level, resetColor, optionalErr)
 		fmt.Println(message...)
+		mu.Unlock()
 		return
 	}
 
+	mu.Lock()
 	fmt.Printf(logPrefix, colorCode, level, resetColor)
 	fmt.Println(message...)
+	mu.Unlock()
 }
 
 // Info logs information messages, so anything that may be interesting to the

--- a/log/log.go
+++ b/log/log.go
@@ -1,10 +1,13 @@
 package log
 
 import (
+	"flag"
 	"fmt"
 	"runtime"
 	"strconv"
 )
+
+var logLvlFlag = flag.Int("log-level", int(DebugLevel), "set loglevels info, error, debug with 1,2,3")
 
 const (
 	resetColor = "\033[0m"
@@ -27,6 +30,10 @@ const (
 
 // log prints the message with the specified color
 func log(colorCode, level string, logLevel LogLevel, optionalErr error, message ...any) {
+	if *logLvlFlag < int(logLevel) {
+		return
+	}
+
 	logPrefix := "%s[%s]%s "
 	if logLevel == ErrorLevel {
 		fmt.Printf(logPrefix+"%+v\n", colorCode, level, resetColor, optionalErr)

--- a/log/log.go
+++ b/log/log.go
@@ -3,8 +3,6 @@ package log
 import (
 	"flag"
 	"fmt"
-	"runtime"
-	"strconv"
 	"sync"
 )
 
@@ -66,25 +64,5 @@ func Error(err error, message ...any) {
 // Debug logs debug messages, so anything that gives information about specific
 // variables and data flow within the application
 func Debug(message ...any) {
-	file, line := trace(3)
-	trace := "\nCalled from  : " + file + ":" + strconv.Itoa(line)
-	message = append(message, trace)
 	log(blueColor, "DEBUG", DebugLevel, nil, message...)
-}
-
-func trace(depth int) (string, int) {
-	pc := make([]uintptr, 5) // Adjust the size as needed
-	n := runtime.Callers(0, pc)
-	frames := runtime.CallersFrames(pc[:n])
-
-	// Skip the first frames, which is the log file
-	f, more := frames.Next()
-	for i := 0; more && i < depth; i++ {
-		f, more = frames.Next()
-		if !more {
-			return "", 0
-		}
-	}
-
-	return f.File, f.Line
 }

--- a/smap/smap.go
+++ b/smap/smap.go
@@ -1,0 +1,43 @@
+package smap
+
+import (
+	"sync"
+)
+
+/*
+* A generic map that is safe for concurrent use, but not optimized for anything.
+ */
+
+type SMap[K comparable, V any] interface {
+	Load(key K) (V, bool)
+	Store(key K, value V)
+}
+
+type smap[K comparable, V any] struct {
+	m  map[K]V
+	mu sync.RWMutex
+}
+
+func NewSMap[K comparable, V any]() SMap[K, V] {
+	m := make(map[K]V)
+	return &smap[K, V]{m, sync.RWMutex{}}
+}
+
+func (s *smap[K, V]) Load(key K) (V, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.m[key]
+	return v, ok
+}
+
+func (s *smap[K, V]) Store(key K, value V) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = value
+}
+
+func (s *smap[K, V]) Delete(key K) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+}


### PR DESCRIPTION
includes :
- adding a map, safe for concurrent use 
- using that map in the eventbus (not using sync.Map because the optimized use cases don't fit ours)
- some fixes and refactoring around logging
- a fix for connections as represented in the core, before a node only had access to its outgoing connections which does not allow for receiving any messages from other nodes